### PR TITLE
feature/apiRefresh-top6 :: 누락된 API들 수정 + API refresh(Notion 참고)

### DIFF
--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.android.tools.idea.compose.preview.runconfiguration.ComposePreviewRunConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/therapist/src/main/java/com/projectTeam/therapist/postService/CommentService.java
+++ b/therapist/src/main/java/com/projectTeam/therapist/postService/CommentService.java
@@ -7,6 +7,7 @@ import org.json.simple.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
@@ -95,5 +96,11 @@ public class CommentService {
     // delete Reply Comment
     public void deleteReplyComment(Long replyCommentId) {
         replyCommentRepository.deleteById(replyCommentId);
+    }
+
+    public List<PostCommentDto> findAllPostCommentsByPostId(Long postId) {
+        PostDto postDto = postRepository.findById(postId).orElse(null);
+
+        return (postDto != null) ? postDto.getPostComments() : new ArrayList<PostCommentDto>();
     }
 }

--- a/therapist/src/main/java/com/projectTeam/therapist/postService/PostService.java
+++ b/therapist/src/main/java/com/projectTeam/therapist/postService/PostService.java
@@ -104,7 +104,22 @@ public class PostService {
         postRepository.deleteById(postId);
     }
 
-    public List<PostDto> requestTopSix() {
-        return postRepository.findTop6ByOrderByPostCreatedAtDesc();
+    public JSONArray requestTopSix() {
+        List<PostDto> posts = postRepository.findTop6ByOrderByPostCreatedAtDesc();
+
+        JSONArray jsonArray = new JSONArray();
+        for (PostDto post : posts) {
+            JSONObject jsonObject = new JSONObject();
+            jsonObject.put("postId", post.getPostId());
+            jsonObject.put("postType", String.valueOf(post.getPostType()));
+            jsonObject.put("postTitle", post.getPostTitle());
+            jsonObject.put("postContent", post.getPostContent());
+            jsonObject.put("postCreatedAt", post.getPostCreatedAt());
+            jsonObject.put("postUpdatedAt", post.getPostUpdatedAt());
+            jsonObject.put("countOfReplies", post.getCountOfReplies());
+
+            jsonArray.add(jsonObject);
+        }
+        return jsonArray;
     }
 }

--- a/therapist/src/main/java/com/projectTeam/therapist/restService/CommentApiController.java
+++ b/therapist/src/main/java/com/projectTeam/therapist/restService/CommentApiController.java
@@ -29,10 +29,15 @@ class CommentApiController {
         return commentService.findAllPostComments();
     }
 
-    // 게시글 댓글(PostComment)의 아이디에 해당하는 게시글 댓글 조회
-    @GetMapping("/postComments/{postCommentId}")
-    PostCommentDto findSinglePostComment(@PathVariable Long postCommentId) {
-        return commentService.findSinglePostComment(postCommentId);
+//    // 게시글 댓글(PostComment)의 아이디에 해당하는 게시글 댓글 조회
+//    @GetMapping("/postComments/{postCommentId}")
+//    PostCommentDto findSinglePostComment(@PathVariable Long postCommentId) {
+//        return commentService.findSinglePostComment(postCommentId);
+//    }
+    // postId에 대한 모든 게시글 댓글을 조회한다.
+    @GetMapping("/postComments/{postId}")
+    List<PostCommentDto> findAllPostCommentsByPostId(@PathVariable Long postId) {
+        return commentService.findAllPostCommentsByPostId(postId);
     }
 
     // 게시글 댓글(PostComment) 생성

--- a/therapist/src/main/java/com/projectTeam/therapist/restService/PostApiController.java
+++ b/therapist/src/main/java/com/projectTeam/therapist/restService/PostApiController.java
@@ -3,6 +3,7 @@ package com.projectTeam.therapist.restService;
 import com.projectTeam.therapist.model.PostCategory;
 import com.projectTeam.therapist.model.PostDto;
 import com.projectTeam.therapist.postService.PostService;
+import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Pageable;
@@ -21,7 +22,7 @@ class PostApiController {
     // 메인 페이지 관련 API
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     @GetMapping("/main/posts")
-    List<PostDto> requestTopSix() {
+    JSONArray requestTopSix() {
         return postService.requestTopSix();
     }
 
@@ -50,7 +51,7 @@ class PostApiController {
 
     }
 
-    @DeleteMapping("/posts/{id}")
+    @DeleteMapping("/posts/{postId}")
     void deletePost(@PathVariable Long postId) {
         postService.deleteById(postId);
     }

--- a/therapist/src/main/java/com/projectTeam/therapist/restService/UserApiController.java
+++ b/therapist/src/main/java/com/projectTeam/therapist/restService/UserApiController.java
@@ -46,10 +46,4 @@ class UserApiController {
     void deleteMyPosts(@RequestBody Map<Long, Long> posts) {
         userService.deleteMyPosts(posts);
     }
-
-    // 마이페이지 체크 박스에 따른 게시글 / 댓글 삭제
-    @PostMapping("/users/mypage")
-    void deleteMyPosts(@RequestBody Map<Long, Long> posts) {
-        userService.deleteMyPosts(posts);
-    }
 }


### PR DESCRIPTION
[Notion_바로가기](https://www.notion.so/API-6ff8b87b5e5f4be283a6e9e747f4fbb8)

- 누락됐던 `특정 게시글(postId)에 대한 댓글(postComments) 조회 API` 추가.
- `가장 최근에 작성한 게시글 TOP 6 출력 API`에서 `postComments` 항목 제거.
- `게시글 삭제 API`에서 @PathVariable 수정