### PR TITLE
Feature/login :: 카카오 로그인과 동시에 jwt Token 담아 프론트로 보내기 

### DIFF
--- a/client/src/components/Header/Sections/NavBarSection/RightMenu.js
+++ b/client/src/components/Header/Sections/NavBarSection/RightMenu.js
@@ -10,40 +10,31 @@ const { kakao } = window;
 function RightMenu() {
     
     const history = useHistory();
-
-    const temp = 2;
-
-
-
-    const onClick = () => {
+    const kakaoLoginClickHandler = () => {
         Kakao.Auth.login({
-            success: function(response) {
-              console.log(response);
+            success: function (authObj) {
+                fetch(`${"http://localhost:8080/auth/kakao/callback?accessToken="+authObj.access_token}`, {
+                    method: "GET",
+                })
+
+                .then(res => res.json())
+                .then(res => {
+                    localStorage.setItem("token", res.token);
+                    if (res.access_token) {
+                        alert("welcome")
+                        history.push("/");
+                    }
+                })
             },
-            fail: function(error) {
-              console.log(error);
-            },
-          });
+            fail: function (err) {
+                alert(JSON.stringify(err))
+            }
+        })
     };
 
-    if (temp === 1){
-
-        return (
-            <div className="nav_menu_right">
-                <Link to='/mypage'><div style={{marginRight:'1rem'}}>MyPage</div></Link>
-                <div>Logout</div>
-            </div>
-        );
-
-    } else {
-
-        return (
-            <div className="nav_menu_right" onClick={onClick}>
-                Login
-            </div>
-        );
-    };
-    
+    return (
+        <Button fill className="btn kakao" onClick={kakaoLoginClickHandler}>카카오 로그인</Button>
+    );
 };
 
 export default RightMenu;

--- a/therapist/src/main/java/com/projectTeam/therapist/configuration/WebConfig.java
+++ b/therapist/src/main/java/com/projectTeam/therapist/configuration/WebConfig.java
@@ -8,6 +8,6 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("http://000.000.00.000:3000");
+                .allowedOrigins("*");
     }
 }

--- a/therapist/src/main/java/com/projectTeam/therapist/userService/AuthController.java
+++ b/therapist/src/main/java/com/projectTeam/therapist/userService/AuthController.java
@@ -6,6 +6,8 @@ import com.projectTeam.therapist.model.LoginDto;
 import com.projectTeam.therapist.model.TokenDto;
 import com.projectTeam.therapist.model.UserDto;
 import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.*;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -34,11 +36,12 @@ public class AuthController {
         this.tokenProvider = tokenProvider;
     }
 
+    @CrossOrigin("*")
     @GetMapping("/kakao/callback")
-    public ResponseEntity<String> kakaoCallback(String code) { // @ResponseBody : Data를 리턴해주는 컨트롤러 함수
-        String accessToken = userService.getAccessToken(code);
+    public JSONObject kakaoCallback(String accessToken) throws ParseException { // @ResponseBody : Data를 리턴해주는 컨트롤러 함수
+        // 프론트에서 Kakao 서버로 인증코드 받아 인증된 사용자면 access token을 보내옴
         Map<String, String> userMap = userService.requestKakaoUserInfo(accessToken);
-
+        System.out.println("accessToken: " + accessToken);
         RestTemplate rt = new RestTemplate();
 
         // builder 이용하여 UserDto 필드 초기화
@@ -49,12 +52,6 @@ public class AuthController {
                 .userThumbnailImage(userMap.get("thumbnail_image"))
                 .userEnabled(true)
                 .build();
-//        UserDto newUser = new UserDto();
-//        newUser.setUserName(userMap.get("username"));
-//        newUser.setUserPassword(userMap.get("password"));
-//        newUser.setUserProfileImage(userMap.get("profile_image"));
-//        newUser.setUserThumbnailImage(userMap.get("thumbnail_image"));
-//        newUser.setUserEnabled(true);
 
         HttpEntity<UserDto> requestEntity = new HttpEntity<>(newUser);
         rt.exchange(
@@ -64,12 +61,18 @@ public class AuthController {
             Void.class
         );
 
-        UserDto kakaoUser = userService.findKakaoUser(userMap.get("username"));
-//        System.out.println("Encrypted Password = " + kakaoUser.getUserPassword());
-        return userService.requestPostWithFormData("/account/login", new LinkedMultiValueMap<String, String>() {{
-            add("username", kakaoUser.getUserName());
-            add("password", userMap.get("password"));
-        }});
+        LoginDto loginDto = LoginDto.builder()
+                .username(userMap.get("username"))
+                .password(userMap.get("password"))
+                .build();
+
+        // LoginDto에 사용자 정보 담아 /auth/authenticate(아래 authorize 메서드) 로 보내면 이를 가지고 jwt 토큰 생성 후 반환
+        String response = userService.requestPostWithFormData("/auth/authenticate", loginDto);
+        JSONParser parser = new JSONParser();
+        Object token = parser.parse(response);
+        JSONObject res = (JSONObject) token;
+
+        return res;
     }
 
     // jwt 토큰 받아오기


### PR DESCRIPTION
> `임시` Kakao Developers에 도메인 주소 프론트로 http://localhost:3000으로 변경

1. 프론트 서버에서 `http://localhost:3000` 접속 후 카카오 로그인 하면
`인가 code`를 받아 `access token`을 발급 받고 백엔드로 전달
2. 전달 받은 `access token`을 가지고 카카오로부터 사용자 정보 받아와 우리 DB에 저장 ( `ID`: 카카오 이메일, `PW`: 임의 문자열 )
3. 우리 DB에 저장된 사용자 정보를 가지고 `JWT 토큰` 생성 후 프론트로 전달
4. 프론트에서 `localStorage`에 `JWT 토큰` 저장
5. 추후 API 사용시 헤더에 `JWT 토큰` 포함해 요청 

https://user-images.githubusercontent.com/37285946/131223104-bb589d9a-b126-4b9e-a3ed-3dc672c0f77f.mp4


  