### PR TITLE
Feature/noticePageable :: Notice API 수정

### DIFF
--- a/therapist/src/main/java/com/projectTeam/therapist/boardService/ReplyService.java
+++ b/therapist/src/main/java/com/projectTeam/therapist/boardService/ReplyService.java
@@ -37,6 +37,7 @@ public class ReplyService {
                 .post_id(postId)
                 .type("reply")
                 .username(postDto.getUserDto().getUserName())
+                .senderUser(userDto.getUserName())
                 .build();
         noticeRepository.save(noticeDto);
 

--- a/therapist/src/main/java/com/projectTeam/therapist/model/NoticeDto.java
+++ b/therapist/src/main/java/com/projectTeam/therapist/model/NoticeDto.java
@@ -1,5 +1,6 @@
 package com.projectTeam.therapist.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -21,6 +22,7 @@ public class NoticeDto {
     private String type;
     private String username;
     private Long post_id;
+    private String senderUser;
     @Builder.Default
     private boolean is_check = false;
 

--- a/therapist/src/main/java/com/projectTeam/therapist/postService/CommentService.java
+++ b/therapist/src/main/java/com/projectTeam/therapist/postService/CommentService.java
@@ -54,6 +54,7 @@ public class CommentService {
                 .post_id(postId)
                 .type("postComment")
                 .username(foundPostDto.getUserDto().getUserName())
+                .senderUser(foundUserDto.getUserName())
                 .build();
         noticeRepository.save(noticeDto);
 
@@ -87,6 +88,7 @@ public class CommentService {
                 .post_id(foundReplyDto.getPostDto().getPostId())
                 .type("replyComment")
                 .username(foundReplyDto.getUserDto().getUserName())
+                .senderUser(foundUserDto.getUserName())
                 .build();
         noticeRepository.save(noticeDto);
 

--- a/therapist/src/main/java/com/projectTeam/therapist/postService/NoticeService.java
+++ b/therapist/src/main/java/com/projectTeam/therapist/postService/NoticeService.java
@@ -7,6 +7,8 @@ import com.projectTeam.therapist.repository.UserRepository;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -22,19 +24,29 @@ public class NoticeService {
         return noticeRepository.save(noticeDto);
     }
 
-    public JSONObject findByUsername(String username) {
-        List<NoticeDto> notices = noticeRepository.findByUsernameOrderByNoticeCreatedAtDesc(username);
+    public JSONObject findByUsername(String username, Pageable pageable) {
+        Page<NoticeDto> notices = noticeRepository.findByUsernameOrderByNoticeCreatedAtDesc(username, pageable);
+        List<NoticeDto> noticeDtos = noticeRepository.findByUsernameOrderByNoticeCreatedAtDesc(username);
+
+        for (NoticeDto notice : noticeDtos) {
+            if (notice.is_check() == false) {
+                notice.set_check(true);
+                noticeRepository.save(notice);
+            }
+        }
 
         JSONObject jsonObject = new JSONObject();
         jsonObject.put("username", username);
+        jsonObject.put("totalAmount", notices.getTotalElements());
         JSONArray jsonArray = new JSONArray();
-        for (NoticeDto notice : notices) {
+        for (NoticeDto notice : notices.getContent()) {
             JSONObject item = new JSONObject();
 
             notice.set_check(true);
             noticeRepository.save(notice);
             item.put("postId", notice.getPost_id());
             item.put("type", notice.getType());
+            item.put("senderUsername", notice.getSenderUser());
             jsonArray.add(item);
         }
         jsonObject.put("notices", jsonArray);

--- a/therapist/src/main/java/com/projectTeam/therapist/repository/NoticeRepository.java
+++ b/therapist/src/main/java/com/projectTeam/therapist/repository/NoticeRepository.java
@@ -1,11 +1,14 @@
 package com.projectTeam.therapist.repository;
 
 import com.projectTeam.therapist.model.NoticeDto;
-import com.projectTeam.therapist.model.UserDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface NoticeRepository extends JpaRepository<NoticeDto, Long> {
     List<NoticeDto> findByUsernameOrderByNoticeCreatedAtDesc(String username);
+    Page<NoticeDto> findByUsernameOrderByNoticeCreatedAtDesc(String username, Pageable pageable);
+
 }

--- a/therapist/src/main/java/com/projectTeam/therapist/restService/NoticeApiController.java
+++ b/therapist/src/main/java/com/projectTeam/therapist/restService/NoticeApiController.java
@@ -3,6 +3,8 @@ package com.projectTeam.therapist.restService;
 import com.projectTeam.therapist.postService.NoticeService;
 import org.json.simple.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
 
 @CrossOrigin("*")
@@ -13,8 +15,8 @@ public class NoticeApiController {
     private NoticeService noticeService;
 
     @GetMapping("/notice/{username}")
-    JSONObject findAllNotices(@PathVariable String username) {
-        return noticeService.findByUsername(username);
+    JSONObject findAllNotices(@PathVariable String username, @PageableDefault(size = 6) final Pageable pageable) {
+        return noticeService.findByUsername(username, pageable);
     }
 
     @GetMapping("/notice/total/{username}")

--- a/therapist/src/main/java/com/projectTeam/therapist/userService/AuthController.java
+++ b/therapist/src/main/java/com/projectTeam/therapist/userService/AuthController.java
@@ -5,6 +5,8 @@ import com.projectTeam.therapist.jwt.TokenProvider;
 import com.projectTeam.therapist.model.LoginDto;
 import com.projectTeam.therapist.model.TokenDto;
 import com.projectTeam.therapist.model.UserDto;
+import com.projectTeam.therapist.postService.NoticeService;
+import com.projectTeam.therapist.repository.NoticeRepository;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
@@ -27,7 +29,8 @@ import java.util.Map;
 public class AuthController {
     @Autowired
     private UserService userService;
-
+    @Autowired
+    private NoticeService noticeService;
     private final TokenProvider tokenProvider;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
 
@@ -65,13 +68,14 @@ public class AuthController {
                 .username(userMap.get("username"))
                 .password(userMap.get("password"))
                 .build();
-
+        int totalNotices = noticeService.findTotalNotice(userMap.get("username"));
         // LoginDto에 사용자 정보 담아 /auth/authenticate(아래 authorize 메서드) 로 보내면 이를 가지고 jwt 토큰 생성 후 반환
         String response = userService.requestPostWithFormData("/auth/authenticate", loginDto);
         JSONParser parser = new JSONParser();
         Object token = parser.parse(response);
         JSONObject res = (JSONObject) token;
         res.put("username", userMap.get("username"));
+        res.put("totalNotices", totalNotices);
 
         return res;
     }


### PR DESCRIPTION
1. 답글/댓글 작성시 Notice 테이블에 답글/댓글 작성 사용자 이름(username)도 `SenderUser` 으로 저장 
![image](https://user-images.githubusercontent.com/37285946/133881372-449ecca2-6413-49b6-83cb-effff7c53e73.png)


2. 로그인시 사용자가 확인하지 않은 알림 개수 `totalNotices`로 반환


3. `/api/notice/{usename}`  API 호출시 사용자가 알림을 모두 확인했으므로 Notice 테이블의 `isCheck` 값 모두 `true`로 변경
![image](https://user-images.githubusercontent.com/37285946/133881450-682aecb2-9711-42dc-9d1b-60663c13eb34.png)

* `/api/notice/{usename}`  API 호출 반환값
![image](https://user-images.githubusercontent.com/37285946/133881536-2497c05f-2022-4991-bb0f-8718d344a701.png)

